### PR TITLE
Add support for custom values in priority UDA/colors

### DIFF
--- a/lua/neowarrior/colors.lua
+++ b/lua/neowarrior/colors.lua
@@ -78,14 +78,10 @@ Colors.get_priority_color = function(priority)
 
   local breakpoints = _Neowarrior.config.breakpoints.priority
 
-  if priority == "H" then
-    return _Neowarrior.config.colors[breakpoints.H].group
-  end
-  if priority == "M" then
-    return _Neowarrior.config.colors[breakpoints.M].group
-  end
-  if priority == "L" then
-    return _Neowarrior.config.colors[breakpoints.L].group
+  for k, v in ipairs(breakpoints) do
+    if k == priority then
+      return _Neowarrior.config.colors[v].group
+    end
   end
 
   return _Neowarrior.config.colors[breakpoints.None].group

--- a/lua/neowarrior/colors.lua
+++ b/lua/neowarrior/colors.lua
@@ -78,7 +78,7 @@ Colors.get_priority_color = function(priority)
 
   local breakpoints = _Neowarrior.config.breakpoints.priority
 
-  for k, v in ipairs(breakpoints) do
+  for k, v in pairs(breakpoints) do
     if k == priority then
       return _Neowarrior.config.colors[v].group
     end


### PR DESCRIPTION
Hi,

First off, cool project!

One thing I noticed when setting up was that priority was fixed to the default values of L, M, H only, while in taskwarrior this is a UDA, that can take an arbitrary value. In my case, I use an additional value that sits above H (T) for top priority.

I made a some minor adjustments to my local version of the plugin to allow me to set the `breakpoints` config to the following:

```lua
priority = {
  T = "danger",
  H = "warning",
  M = "info",
  L = "default",
  None = "default",
}
```

In theory, this should allow any user defined values to be used, and should match them up accordingly. Have tested it in my local setup and seems to be working fine.

Figured I'd throw this in a PR in case it was useful, but feel free to discard if this is not a direction you want to take with it.

Thanks for the plugin :) 